### PR TITLE
add subset notebook

### DIFF
--- a/notebooks/subset_models_with_intake.ipynb
+++ b/notebooks/subset_models_with_intake.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "import gcsfs\n",
+    "from scipy import signal\n",
+    "import util\n",
+    "import intake"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Experiments to process\n",
+    "experiment_ids = ['historical', 'ssp370']\n",
+    "\n",
+    "# Seasons to process\n",
+    "seasons = ['all','DJF','JJA']\n",
+    "\n",
+    "time_range = [1976, 2085]\n",
+    "# Time slices (future) to process\n",
+    "time_slices = ([['2006','2035'],\n",
+    "                ['2016','2045'],\n",
+    "                ['2026','2055'],\n",
+    "                ['2036','2065'],\n",
+    "                ['2046','2075'],\n",
+    "                ['2056','2085']])\n",
+    "\n",
+    "variable_ids = ['pr','tas','huss']\n",
+    "\n",
+    "table_ids = ['Amon','day']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if util.is_ncar_host():\n",
+    "    col = intake.open_esm_datastore(\"../catalogs/glade-cmip6.json\")\n",
+    "else:\n",
+    "    col = intake.open_esm_datastore(\"../catalogs/pangeo-cmip6.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# subset to overall things we're looking at\n",
+    "subset = col.search(experiment_id=experiment_ids, \n",
+    "                    variable_id=variable_ids,\n",
+    "                    table_id=table_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# subset to models that have all the variables we want\n",
+    "# daily pr; monthly tas, pr, huss\n",
+    "uni_dict = subset.unique(['source_id','table_id','variable_id'])\n",
+    "models = set(uni_dict['source_id']['values']) # all the models\n",
+    "cat_day = subset.search(table_id='day', variable_id='pr')\n",
+    "models = models.intersection({model for model in cat_day.df.source_id.unique().tolist()})\n",
+    "for v in variable_ids:\n",
+    "    query = dict(variable_id=v, table_id='Amon')\n",
+    "    cat = col.search(**query)\n",
+    "    models = models.intersection({model for model in cat.df.source_id.unique().tolist()})\n",
+    "\n",
+    "models = list(models)\n",
+    "\n",
+    "# subset to relevant models\n",
+    "our_models = subset.search(source_id=models)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## subset on years\n",
+    "model_df = our_models.df.copy()\n",
+    "\n",
+    "# clean up dates\n",
+    "years = model_df.time_range.str.split('-', expand=True).apply(lambda ser: ser.str[:4]).astype(int)\n",
+    "\n",
+    "# subset\n",
+    "valid = ((years[0]>= time_range[0]) & (years[0] <= time_range[1]) | \n",
+    "         (years[1]>= time_range[0]) & (years[1] <= time_range[1]))\n",
+    "\n",
+    "# return to our collection\n",
+    "our_models.df = model_df[valid]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# confirm that there aren't duplicates over grid label, version, or activity_id, since these aren't really separate models\n",
+    "assert not (our_models.search(experiment_id='ssp370').df.duplicated(subset=set(our_models.df.columns)-\n",
+    "                                                            {'activity_id','grid_label','path','version'}).any())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CMIP6 2019.10",
+   "language": "python",
+   "name": "cmip6-201910"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Use `intake-esm` to subset down to only the assets we will need to load.

- only including models that have all of these variables (monthly tas, huss, pr and daily pr)
- doing some other subsetting
- should be flexible across glade and ocean.pangeo, although the models it returns could be different if the catalogs are different

This can be merged into @ks905383 's notebook as we continue forward